### PR TITLE
Fix toast hook listener leak

### DIFF
--- a/project/app/hooks/use-toast.ts
+++ b/project/app/hooks/use-toast.ts
@@ -179,7 +179,7 @@ function useToast() {
         listeners.splice(index, 1);
       }
     };
-  }, [state]);
+  }, []);
 
   return {
     ...state,


### PR DESCRIPTION
## Summary
- fix subscription effect in `use-toast` so listeners are only added on mount

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5ece9c3c832ab19087b234b162fc